### PR TITLE
Add domain for Surigao del Norte State University

### DIFF
--- a/lib/domains/ph/edu/ssct.txt
+++ b/lib/domains/ph/edu/ssct.txt
@@ -1,0 +1,1 @@
+Surigao del Norte State University (formerly known as Surigao State College of Technology)


### PR DESCRIPTION
SNSU is formerly known as SSCT or Surigao State College of Technology.